### PR TITLE
fix: Restore $all operator

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1123,6 +1123,20 @@ type AddToSetOperator = {
  */
 const $addToSet = se('$addToSet');
 
+type AllOperator = {
+  $all: ArrayExpression,
+}
+
+/**
+ * Selects documents where the value of a field is an array that contains all
+ * the specified elements.
+ * @function
+ * @category Other Operators
+ * @param {...Expression[]} expressions Match expression.
+ * @returns {AllOperator} The compiled $all operator.
+ */
+const $all = (...expressions: Expression[] ) => ({ $all: [...expressions ]});
+
 type AllElementsTrueOperator = {
   $allElementsTrue: Array<Expression>,
 };
@@ -3532,6 +3546,8 @@ export = {
   addFields: $addFields,
   $addToSet,
   addToSet: $addToSet,
+  $all,
+  all: $all,
   $allElementsTrue,
   allElementsTrue: $allElementsTrue,
   $and,

--- a/pipeline.test.ts
+++ b/pipeline.test.ts
@@ -450,6 +450,16 @@ describe('aggregation', () => {
         expect($.addToSet('$myVar')).toEqual({ $addToSet: '$myVar' });
       });
     });
+    describe('$all', () => {
+      it('exports expected vars', () => {
+        expect($.all).toBeDefined();
+        expect($.$all).toBeDefined();
+        expect($.all).toStrictEqual($.$all);
+      });
+      it('returns expected result', () => {
+        expect($.all(1, 2, 3)).toEqual({ $all: [1, 2, 3] });
+      });
+    });
     describe('$allElementsTrue', () => {
       it('exports expected vars', () => {
         expect($.allElementsTrue).toBeDefined();


### PR DESCRIPTION
This is another operator that is documented as a query operator but not as an aggregation operator.